### PR TITLE
fix(core): skip JS injection on non-HTML pages

### DIFF
--- a/orestbida-cookie-consent.php
+++ b/orestbida-cookie-consent.php
@@ -86,6 +86,11 @@ class OrestbidaCookieConsentPlugin extends Plugin
      */
     public function onTwigSiteVariables(): void
     {
+        $page = $this->grav['page'];
+        if ($page && $page->templateFormat() !== 'html') {
+          return;
+        }
+
         $assets = $this->grav['assets'];
         
         // Validate and get configuration
@@ -125,6 +130,11 @@ class OrestbidaCookieConsentPlugin extends Plugin
      */
     public function onOutputGenerated(): void
     {
+        $page = $this->grav['page'];
+        if ($page && $page->templateFormat() !== 'html') {
+          return;
+        }
+
         try {
             // Get the current output
             $output = $this->grav->output;


### PR DESCRIPTION
Do not include the cookie consent JS script on pages that are not rendered as HTML (e.g. JSON, XML, RSS feeds).

Fixes pmoreno-rodriguez/grav-plugin-orestbida-cookie-consent#4